### PR TITLE
Fixed parse errors due to invalid html in documentation

### DIFF
--- a/ThermoCycle/Components/HeatFlow/HeatTransfer/BaseClass/PartialHeatTransfer.mo
+++ b/ThermoCycle/Components/HeatFlow/HeatTransfer/BaseClass/PartialHeatTransfer.mo
@@ -27,7 +27,7 @@ equation
 annotation(Documentation(info="<html>
 <p><big> The Partial model <b>PartialHeatTransfer</b> is the basic model for heat transfer of a real fluid in the library. It calculates the
 heat flux, q_dot[n], exchanged through the thermal port, ThermalPortL[n], for each segment n, based on the thermodynamic state of the fluid flow ,FluidState[n],  
-and the temperatures at the boundary, T_fluid and thermalPortL.T.<\p>
+and the temperatures at the boundary, T_fluid and thermalPortL.T.</p>
 <p><big> In order to complete the model - from <FONT COLOR=blue>partial model</FONT>  to <FONT COLOR=blue> model</FONT> -
  one equation relating the exchanged heat flux, q_dot, with the fluid temperature, T_fluid,
 and the temperature at the boundary thermalPortL.T has to be privided.  

--- a/ThermoCycle/Components/Units/package.mo
+++ b/ThermoCycle/Components/Units/package.mo
@@ -13,7 +13,7 @@ annotation (Documentation(info="<HTML>
 <li><strong><a href=\"modelica://ThermoCycle.Components.Units.PdropAndValves\">PdropAndValves</a>
 <li><strong><a href=\"modelica://ThermoCycle.Components.Units.Tanks\">Tanks</a>
 <li><strong><a href=\"modelica://ThermoCycle.Components.Units.Solar\">Solar</a>
-<\ul>
+</ul>
 
 <p><big><dl><dt><b>Main Authors:</b> <br/></dt>
 <dd>Sylvain Quoilin; &LT;<a href=\"squoilin@ulg.ac.be\">squoilin@ulg.ac.be</a>&GT;</dd>

--- a/ThermoCycle/package.mo
+++ b/ThermoCycle/package.mo
@@ -1,4 +1,4 @@
-﻿within ;
+within ;
 package ThermoCycle "A library for the simulation of thermal systems"
 
 
@@ -21,7 +21,7 @@ The interface between ThermoCycle and CoolProp on the Modelica level is ensured 
 <p><big>The library requires the CoolProp Modelica wrapper to be installed on the target system. This wrapper can be downloaded and compiled from the  CoolProp website <a href=\"http://coolprop.sourceforge.net/HowGetIt.html\">http://www.http://coolprop.sourceforge.net/</a>. Pre-compiled versions using VisualStudio2010 and VisualStudio2008 
 have also been made available. 
 
-Once downloaded the CoolPropLib.lib file has to be copied in the “Dymola \ bin\lib\” folder of the Dymola installation, usually in C:\Program Files\ .
+Once downloaded the CoolPropLib.lib file has to be copied in the \"Dymola\\bin\\lib\\\" folder of the Dymola installation, usually in C:\\Program Files\\ .
 
 </p>
 <p></p>


### PR DESCRIPTION
There were a few instances of invalid html in documentation causing parse errors.
